### PR TITLE
Fix exception in combat check.

### DIFF
--- a/scripts/actions/dnd5e/dnd5e-actions.js
+++ b/scripts/actions/dnd5e/dnd5e-actions.js
@@ -528,6 +528,8 @@ export class ActionHandler5e extends ActionHandler {
     /** @private */
     _addIntiativeSubcategory(macroType, category, tokenId) {
         const combat = game.combat;
+        if (!combat)
+            return;
         const combatant = combat.combatants.find(c => c.tokenId === tokenId);
         if (!combatant)
             return;


### PR DESCRIPTION
There is a bug which causes the HUD to not display if there is no combat active, this is due to an exception thrown when calling combat.combatants.find on a null combat. Add a check on the combat and exit early if there isn't one.