### PR TITLE
short rest macro name change

### DIFF
--- a/scripts/rollHandlers/pf2e/pf2e-base.js
+++ b/scripts/rollHandlers/pf2e/pf2e-base.js
@@ -448,7 +448,7 @@ export class RollHandlerBasePf2e extends RollHandler {
 
         switch(actionId) {
             case 'shortRest':
-                this._executeMacroByName('Treat Wounds Macro');
+                this._executeMacroByName('Treat Wounds');
                 break;
             case 'longRest':
                 this._executeMacroByName('Rest for the Night');


### PR DESCRIPTION
The "Treat Wounds Macro" was renamed to just "Treat Wounds" in a recent system update, I changed the call here so that it works again. Happy New Year!