### PR TITLE
Add new category for class-features used for sw5e system only

### DIFF
--- a/lang/br.json
+++ b/lang/br.json
@@ -57,6 +57,7 @@
   "tokenactionhud.tools": "Ferramentas",
 
   "tokenactionhud.features": "Talentos",
+  "tokenactionhud.classFeatures": "Características da aula",
   "tokenactionhud.levelAbbreviation": "Lvl",
   
   "tokenactionhud.blocklistLabel": "Lista Bloquiada (somente esconder) ou Lista Permitida (somente exibir)",

--- a/lang/cn.json
+++ b/lang/cn.json
@@ -26,6 +26,7 @@
     "tokenactionhud.magicItems": "魔法物品",
     "tokenactionhud.feats": "专长",
     "tokenactionhud.features": "特性",
+	"tokenactionhud.classFeatures": "班级特色",
     "tokenactionhud.free": "自由",
     "tokenactionhud.inconsumables": "非消耗品",
     "tokenactionhud.instinct": "直感",

--- a/lang/en.json
+++ b/lang/en.json
@@ -28,6 +28,7 @@
     "tokenactionhud.magicItems": "Magic Items",
     "tokenactionhud.feats": "Feats",
     "tokenactionhud.features": "Features",
+	"tokenactionhud.classFeatures": "Class Features",
     "tokenactionhud.free": "Free",
     "tokenactionhud.inconsumables": "Inconsumables",
     "tokenactionhud.instinct": "Instinct",

--- a/lang/es.json
+++ b/lang/es.json
@@ -11,6 +11,7 @@
     "tokenactionhud.dmg": "Dañ",
     "tokenactionhud.feats": "Dotes",
     "tokenactionhud.features": "Dotes",
+	"tokenactionhud.classFeatures": "Características de clase",
     "tokenactionhud.inconsumables": "Consumibles",
     "tokenactionhud.instinct": "Instinto",
     "tokenactionhud.monsterMoves": "Movimientos de Monstruo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -25,6 +25,7 @@
     "tokenactionhud.equipment": "Equipement",
     "tokenactionhud.magicItems": "Objets Magiques",
     "tokenactionhud.feats": "Dons",
+	"tokenactionhud.classFeatures": "Capacités de classe",
     "tokenactionhud.features": "Capacités",
     "tokenactionhud.free": "Libre",
     "tokenactionhud.inconsumables": "Non consommables",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -28,6 +28,7 @@
     "tokenactionhud.magicItems": "魔法アイテム",
     "tokenactionhud.feats": "特技",
     "tokenactionhud.features": "特徴",
+	"tokenactionhud.classFeatures": "クラスの特徴",
     "tokenactionhud.free": "無料",
     "tokenactionhud.inconsumables": "非消耗品",
     "tokenactionhud.instinct": "直感",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -25,6 +25,7 @@
     "tokenactionhud.equipment": "장비",
     "tokenactionhud.magicItems": "매직 아이템",
     "tokenactionhud.feats": "피트",
+	"tokenactionhud.classFeatures": "Class Features",
     "tokenactionhud.features": "특징",
     "tokenactionhud.free": "자유",
     "tokenactionhud.inconsumables": "비소모품",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -25,6 +25,7 @@
   "tokenactionhud.equipment": "Ekwipunek",
   "tokenactionhud.magicItems": "Magiczne Przedmioty",
   "tokenactionhud.feats": "Feats",
+  "tokenactionhud.classFeatures": "Class Features",
   "tokenactionhud.features": "Features",
   "tokenactionhud.free": "Darmowe",
   "tokenactionhud.inconsumables": "Inconsumables",

--- a/scripts/actions/sw5e/sw5e-actions.js
+++ b/scripts/actions/sw5e/sw5e-actions.js
@@ -34,17 +34,20 @@ export class ActionHandlerSw5e extends ActionHandler {
         let items = this._getItemList(actor, tokenId);
         let powers = this._getPowersList(actor, tokenId);
         let feats = this._getFeatsList(actor, tokenId);
+		let classFeatures = this._getClassFeaturesList(actor, tokenId);
         let skills = this._getSkillsList(actor.data.data.skills, tokenId);
         let utility = this._getUtilityList(actor, tokenId);
 
         let itemsTitle = this.i18n('tokenactionhud.inventory');
         let powersTitle = this.i18n('tokenactionhud.powers');
         let featsTitle = this.i18n('tokenactionhud.features');
+		let classFeaturesTitle = this.i18n('tokenactionhud.classFeatures');
         let skillsTitle = this.i18n('tokenactionhud.skills');
         
         this._combineCategoryWithList(result, itemsTitle, items);
         this._combineCategoryWithList(result, powersTitle, powers);
         this._combineCategoryWithList(result, featsTitle, feats);
+		this._combineCategoryWithList(result, classFeaturesTitle, classFeatures);
         this._combineCategoryWithList(result, skillsTitle, skills);
 
         let savesTitle = this.i18n('tokenactionhud.saves');
@@ -306,6 +309,24 @@ export class ActionHandlerSw5e extends ActionHandler {
             power.info2 += this.i18n('SW5E.Concentration').charAt(0).toUpperCase();
     }
     
+	/** Class Features **/
+		/** I Added a new category, but you can add Class Features to Feats category.
+		If you prefer that, just update _getFeatsList and replace:
+		i.type == 'feat'
+		by
+		i.type == 'feat' || i.type == 'classfeature'
+		**/
+	
+	    /** @private */
+    _getClassFeaturesList(actor, tokenId) {
+        let validClassfeature = this._filterLongerActions(actor.data.items.filter(i => i.type == 'classfeature'));
+		// We can use the same method use by feat, classFeatures are using same kind of data
+        let sortedClassfeature = this._sortByItemSort(validClassfeature);
+        let classfeatures = this._categoriseFeats(tokenId, actor, sortedClassfeature);
+    
+        return classfeatures;
+    }
+	
     /** FEATS **/
 
     /** @private */


### PR DESCRIPTION
Add a new category for system **sw5e only** to display _class features_ from character sheet.
Add comment into sw5e-actions.js to explain how to do if you prefer to add class-feature into feats category.

Indeed, class features and feats are pretty closed and has same kind of data.
i18n have been modify too and translate if possible using Google trad. At least, new key has been added in json.