### PR TITLE
Add conditions category for sw5e only

### DIFF
--- a/scripts/actions/sw5e/sw5e-actions.js
+++ b/scripts/actions/sw5e/sw5e-actions.js
@@ -37,12 +37,16 @@ export class ActionHandlerSw5e extends ActionHandler {
 		let classFeatures = this._getClassFeaturesList(actor, tokenId);
         let skills = this._getSkillsList(actor.data.data.skills, tokenId);
         let utility = this._getUtilityList(actor, tokenId);
+		let conditions;
+        if (settings.get('showConditionsCategory'))
+            conditions = this._getConditionsList(actor, tokenId);
 
         let itemsTitle = this.i18n('tokenactionhud.inventory');
         let powersTitle = this.i18n('tokenactionhud.powers');
         let featsTitle = this.i18n('tokenactionhud.features');
 		let classFeaturesTitle = this.i18n('tokenactionhud.classFeatures');
         let skillsTitle = this.i18n('tokenactionhud.skills');
+		let conditionsTitle = this.i18n('tokenactionhud.conditions');
         
         this._combineCategoryWithList(result, itemsTitle, items);
         this._combineCategoryWithList(result, powersTitle, powers);
@@ -57,6 +61,7 @@ export class ActionHandlerSw5e extends ActionHandler {
         
         this._combineCategoryWithList(result, savesTitle, saves);
         this._combineCategoryWithList(result, checksTitle, checks);
+		this._combineCategoryWithList(result, conditionsTitle, conditions);
     
         let utilityTitle = this.i18n('tokenactionhud.utility');
         this._combineCategoryWithList(result, utilityTitle, utility);
@@ -83,6 +88,9 @@ export class ActionHandlerSw5e extends ActionHandler {
         this._addMultiAbilities(list, tokenId, 'saves', savesTitle, 'abilitySave');
         this._addMultiAbilities(list, tokenId, 'checks', checksTitle, 'abilityCheck');
 
+		if (settings.get('showConditionsCategory'))
+            this._addMultiConditions(list, tokenId);
+		
         this._addMultiUtilities(list, tokenId, actors);
     }
     
@@ -528,6 +536,68 @@ export class ActionHandlerSw5e extends ActionHandler {
     }
 
 
+	/** CONDITIONS **/
+	
+	    /** @private */
+    _getConditionsList(actor, tokenId) {
+        let result = this.initializeEmptyCategory('conditions');
+        this._addConditionsSubcategory(actor, tokenId, result);
+        return result;
+    }
+	
+	    /** @private */
+    _addConditionsSubcategory(actor, tokenId, category) {
+        const macroType = 'condition';
+
+        const availableConditions = CONFIG.statusEffects.filter(condition => condition.id !== '');
+
+        if (!availableConditions)
+            return;
+
+        let conditions = this.initializeEmptySubcategory();
+
+        availableConditions.forEach(c => {
+            const name = this.i18n(c.label);
+            const encodedValue = [macroType, tokenId, c.id].join(this.delimiter);
+            const cssClass = actor.effects.entries.some(e => e.data.flags.core?.statusId === c.id) ? 'active' : '';
+            const image = c.icon;
+            const action = {name: name, id: c.id, encodedValue: encodedValue, img: image, cssClass: cssClass}
+
+            conditions.actions.push(action);
+        });
+
+        this._combineSubcategoryWithCategory(category, this.i18n('tokenactionhud.conditions'), conditions);
+    }
+	
+	 /** @private */
+    _addMultiConditions(list, tokenId) {
+        const category = this.initializeEmptyCategory('conditions');
+        const macroType = 'condition';
+
+        const availableConditions = CONFIG.statusEffects.filter(condition => condition.id !== '');
+        const actors = canvas.tokens.controlled.filter(t => !!t.actor).map(t => t.actor);
+
+        if (!availableConditions)
+            return;
+
+        let conditions = this.initializeEmptySubcategory();
+
+        availableConditions.forEach(c => {
+            const name = this.i18n(c.label);
+            const encodedValue = [macroType, tokenId, c.id].join(this.delimiter);
+            const cssClass = actors.every(actor => actor.effects.entries.some(e => e.data.flags.core?.statusId === c.id)) ? 'active' : '';
+            const image = c.icon;
+            const action = {name: name, id: c.id, encodedValue: encodedValue, img: image, cssClass: cssClass}
+
+            conditions.actions.push(action);
+        });
+
+        const conName = this.i18n('tokenactionhud.conditions');
+        this._combineSubcategoryWithCategory(category, conName, conditions);
+        this._combineCategoryWithList(list, conName, category);
+    }
+	/** END CONDITIONS **/
+	
     /** @private */
     _buildItem(tokenId, actor, macroType, item) {
         let encodedValue = [macroType, tokenId, item._id].join(this.delimiter);

--- a/scripts/rollHandlers/sw5e/sw5e-base.js
+++ b/scripts/rollHandlers/sw5e/sw5e-base.js
@@ -7,7 +7,7 @@ export class RollHandlerBaseSw5e extends RollHandler {
     }
 
     /** @override */
-    doHandleActionEvent(event, encodedValue) {
+    async doHandleActionEvent(event, encodedValue) {
         let payload = encodedValue.split('|');
         
         if (payload.length != 3) {
@@ -28,7 +28,7 @@ export class RollHandlerBaseSw5e extends RollHandler {
         }
     }
 
-    _handleMacros(event, macroType, tokenId, actionId) {
+    async _handleMacros(event, macroType, tokenId, actionId) {
         switch (macroType) {
             case "ability":
                 this.rollAbilityMacro(event, tokenId, actionId);
@@ -50,8 +50,20 @@ export class RollHandlerBaseSw5e extends RollHandler {
                 else
                     this.rollItemMacro(event, tokenId, actionId);
                 break;
+			 case "classFeatures": 
+                if (this.isRenderItem())
+                    this.doRenderItem(tokenId, actionId);
+                else
+                    this.rollItemMacro(event, tokenId, actionId);
+                break;
             case "utility":
                 this.performUtilityMacro(event, tokenId, actionId);
+				break;
+			case 'effect':
+                await this.toggleEffect(event, tokenId, actionId);
+                break;
+            case 'condition':
+                await this.toggleCondition(event, tokenId, actionId);
             default:
                 break;
         }
@@ -122,5 +134,48 @@ export class RollHandlerBaseSw5e extends RollHandler {
                 actor.rollDeathSave();
                 break;
         }
+    }
+	
+	    async toggleCondition(event, tokenId, effectId) {
+        const token = super.getToken(tokenId);
+        const isRightClick = this.isRightClick(event);
+        if (effectId.includes('combat-utility-belt.') && game.cub && !isRightClick) {
+            const cubCondition = this.findCondition(effectId)?.label;            
+            if (!cubCondition)
+                return;
+            
+            game.cub.hasCondition(cubCondition, token) ? 
+                await game.cub.removeCondition(cubCondition, token) : await game.cub.addCondition(cubCondition, token);
+        } else {
+            const condition = this.findCondition(effectId);
+            if (!condition)
+                return;
+            
+            isRightClick ? 
+                await token.toggleOverlay(condition) : await token.toggleEffect(condition);
+        }
+
+        Hooks.callAll('forceUpdateTokenActionHUD')
+    }
+	
+	    async toggleEffect(event, tokenId, effectId) {
+        const actor = super.getActor(tokenId);
+        const effect = actor.effects.entries.find(e => e.id === effectId);
+
+        if (!effect)
+            return;
+
+        const statusId = effect.data.flags.core?.statusId;
+        if (statusId) {
+            await this.toggleCondition(event, tokenId, statusId);
+            return;
+        }
+            
+        await effect.update({disabled: !effect.data.disabled});
+        Hooks.callAll('forceUpdateTokenActionHUD')
+    }
+
+    findCondition(id) {
+        return CONFIG.statusEffects.find(effect => effect.id === id);
     }
 }

--- a/scripts/settings/sw5e-settings.js
+++ b/scripts/settings/sw5e-settings.js
@@ -38,5 +38,15 @@ export function register(app, updateSettings) {
         default: false,
         onChange: value => { updateSettings(value); }
     });
+	
+	    game.settings.register(app,'showConditionsCategory', {
+        name: game.i18n.localize('tokenactionhud.settings.dnd5e.showConditionsCategory.name'),
+        hint: game.i18n.localize('tokenactionhud.settings.dnd5e.showConditionsCategory.hint'),
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: true,
+        onChange: value => { updateFunc(value); }
+    });
 }
     


### PR DESCRIPTION
Hello,

I have add to **sw5e** system only the "conditions" category that already existed for **dnd5e** system .
Add also the auto "apply effect" when a condition is added to a token.
Add to configuration section for **sw5e** system only the possibility to hide the "condition" section like it's possible for **dnd5e** system.