### PR TITLE
Show pathfinder 1e skills if training not required.

### DIFF
--- a/scripts/actions/pf1/pf1-actions.js
+++ b/scripts/actions/pf1/pf1-actions.js
@@ -441,7 +441,8 @@ export class ActionHandlerPf1 extends ActionHandler {
             let id = e[0];
             let data = e[1];
 
-            if (!data.rank) {
+            // rt: requires training
+            if (data.rt && !data.rank) {
                 return null;
             }
 


### PR DESCRIPTION
Pathfinder 1e has the concept of trained/untrained skills, as mentioned in #175. A change was made (https://github.com/espositos/fvtt-tokenactionhud/commit/59dfefe094a56b1771c30acd4c816c7a8605d3e5) to show only skills that have rank != 0, but skills that don't need training should also be shown. I think this should fix things, but I'm new to foundry dev and haven't yet figured out how to test it locally (don't know how to install development modules).