### PR TITLE
fix death check roll for sw5e

### DIFF
--- a/scripts/rollHandlers/sw5e/sw5e-base.js
+++ b/scripts/rollHandlers/sw5e/sw5e-base.js
@@ -131,7 +131,7 @@ export class RollHandlerBaseSw5e extends RollHandler {
                 token.toggleVisibility();
                 break;
             case 'deathSave':
-                actor.rollDeathSave();
+                actor.rollDeathSave({event});
                 break;
         }
     }


### PR DESCRIPTION
Hello,
simple fix for death save roll for sw5e system which was lacking argument on calls

Best regards