### PR TITLE
Update demonlord-base.js

### DIFF
--- a/scripts/rollHandlers/demonlord/demonlord-base.js
+++ b/scripts/rollHandlers/demonlord/demonlord-base.js
@@ -35,7 +35,8 @@ export class RollHandlerBaseDemonlord extends RollHandler {
 
         switch (macroType) {
             case 'challenge':
-                actor.rollChallenge(actionId);
+                const attribute = actor ? actor.data.data.attributes[actionId] : null
+                actor.rollChallenge(attribute, actionId);
                 break;
             case 'weapon':
                 actor.rollWeaponAttack(item._id, null);


### PR DESCRIPTION
Challenge rolls are not working on current version of SotDL system.
rollChallenge takes 2 arguments.